### PR TITLE
Add an option to use an external version of FreeType, and make install target optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,14 @@ set(PLUTOSVG_VERSION_MICRO 7)
 
 project(plutosvg LANGUAGES C VERSION ${PLUTOSVG_VERSION_MAJOR}.${PLUTOSVG_VERSION_MINOR}.${PLUTOSVG_VERSION_MICRO})
 
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  set(PLUTOSVG_MAINPROJECT ON)
+else()
+  set(PLUTOSVG_MAINPROJECT OFF)
+endif()
+
+option(PLUTOSVG_INSTALL "Enable installation of PlutoSVG" ${PLUTOSVG_MAINPROJECT})
+
 find_package(plutovg 1.0.0 QUIET)
 if(NOT plutovg_FOUND)
     add_subdirectory(plutovg)
@@ -52,10 +60,19 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 option(PLUTOSVG_ENABLE_FREETYPE "Enable Freetype integration" OFF)
+option(PLUTOSVG_EXTERNAL_FREETYPE "Use the available freetype instead of finding it" OFF)
 if(PLUTOSVG_ENABLE_FREETYPE)
-    find_package(Freetype 2.12 REQUIRED)
     target_compile_definitions(plutosvg PUBLIC PLUTOSVG_HAS_FREETYPE)
-    target_link_libraries(plutosvg PUBLIC Freetype::Freetype)
+    if (NOT PLUTOSVG_EXTERNAL_FREETYPE)
+        find_package(Freetype 2.12 REQUIRED)
+        target_link_libraries(plutosvg PUBLIC Freetype::Freetype)
+    else()
+        if (NOT TARGET freetype)
+            message(FATAL_ERROR "FreeType not available.")
+        else()
+            target_link_libraries(plutosvg PUBLIC freetype)
+        endif()
+    endif()
 endif()
 
 configure_package_config_file(
@@ -69,78 +86,80 @@ write_basic_package_version_file(plutosvgConfigVersion.cmake
     COMPATIBILITY SameMajorVersion
 )
 
-install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/source/plutosvg.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/source/plutosvg-ft.h
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/plutosvg
-)
+if (PLUTOSVG_INSTALL)
+    install(FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/source/plutosvg.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/source/plutosvg-ft.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/plutosvg
+    )
 
-install(TARGETS plutosvg
-    EXPORT plutosvgTargets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+    install(TARGETS plutosvg
+        EXPORT plutosvgTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
 
-install(EXPORT plutosvgTargets
-    FILE plutosvgTargets.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/plutosvg
-    NAMESPACE plutosvg::
-)
+    install(EXPORT plutosvgTargets
+        FILE plutosvgTargets.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/plutosvg
+        NAMESPACE plutosvg::
+    )
 
-install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/plutosvgConfig.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/plutosvgConfigVersion.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/plutosvg
-)
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/plutosvgConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/plutosvgConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/plutosvg
+    )
 
-export(EXPORT plutosvgTargets
-    FILE ${CMAKE_CURRENT_BINARY_DIR}/plutosvgTargets.cmake
-    NAMESPACE plutosvg::
-)
+    export(EXPORT plutosvgTargets
+        FILE ${CMAKE_CURRENT_BINARY_DIR}/plutosvgTargets.cmake
+        NAMESPACE plutosvg::
+    )
 
-file(RELATIVE_PATH plutosvg_pc_prefix_relative
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    "${CMAKE_INSTALL_PREFIX}"
-)
+    file(RELATIVE_PATH plutosvg_pc_prefix_relative
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+        "${CMAKE_INSTALL_PREFIX}"
+    )
 
-set(plutosvg_pc_cflags "")
-set(plutosvg_pc_libs_private "")
-set(plutosvg_pc_requires "")
+    set(plutosvg_pc_cflags "")
+    set(plutosvg_pc_libs_private "")
+    set(plutosvg_pc_requires "")
 
-if(MATH_LIBRARY)
-    string(APPEND plutosvg_pc_libs_private " -lm")
+    if(MATH_LIBRARY)
+        string(APPEND plutosvg_pc_libs_private " -lm")
+    endif()
+
+    if(NOT BUILD_SHARED_LIBS)
+        string(APPEND plutosvg_pc_cflags " -DPLUTOSVG_BUILD_STATIC")
+    endif()
+
+    if(PLUTOSVG_ENABLE_FREETYPE)
+        string(APPEND plutosvg_pc_cflags " -DPLUTOSVG_HAS_FREETYPE")
+        string(APPEND plutosvg_pc_requires " freetype2 >= 2.12")
+    endif()
+
+    string(CONFIGURE [[
+    prefix=${pcfiledir}/@plutosvg_pc_prefix_relative@
+    includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+    libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+    Name: PlutoSVG
+    Description: Tiny SVG rendering library in C
+    Version: @PROJECT_VERSION@
+
+    Requires: plutovg@plutosvg_pc_requires@
+    Cflags: -I${includedir}/plutosvg@plutosvg_pc_cflags@
+    Libs: -L${libdir} -lplutosvg
+    Libs.private:@plutosvg_pc_libs_private@
+    ]] plutosvg_pc @ONLY)
+
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/plutosvg.pc" "${plutosvg_pc}")
+
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/plutosvg.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+    )
 endif()
-
-if(NOT BUILD_SHARED_LIBS)
-    string(APPEND plutosvg_pc_cflags " -DPLUTOSVG_BUILD_STATIC")
-endif()
-
-if(PLUTOSVG_ENABLE_FREETYPE)
-    string(APPEND plutosvg_pc_cflags " -DPLUTOSVG_HAS_FREETYPE")
-    string(APPEND plutosvg_pc_requires " freetype2 >= 2.12")
-endif()
-
-string(CONFIGURE [[
-prefix=${pcfiledir}/@plutosvg_pc_prefix_relative@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-
-Name: PlutoSVG
-Description: Tiny SVG rendering library in C
-Version: @PROJECT_VERSION@
-
-Requires: plutovg@plutosvg_pc_requires@
-Cflags: -I${includedir}/plutosvg@plutosvg_pc_cflags@
-Libs: -L${libdir} -lplutosvg
-Libs.private:@plutosvg_pc_libs_private@
-]] plutosvg_pc @ONLY)
-
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/plutosvg.pc" "${plutosvg_pc}")
-
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/plutosvg.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-)
 
 option(PLUTOSVG_BUILD_EXAMPLES "Build examples" ON)
 if(PLUTOSVG_BUILD_EXAMPLES)


### PR DESCRIPTION
When using FreeType as a submodule (or including FreeType’s source code by any other means), the current CMake configuration generates an error if FreeType is not installed, even if it’s already available as a target.

This PR adds an option, PLUTOSVG_EXTERNAL_FREETYPE, which links against the locally available FreeType instead of locating it via find_package.

It also introduces an option, PLUTOSVG_INSTALL, which defaults to ON if this is the top-level CMake project and OFF otherwise. Users can override it to disable the install target and make it optional.

Note: The install target makes using FreeType directly impossible.