### PR TITLE
Silence deprecation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(plutosvg PUBLIC PLUTOSVG_BUILD_STATIC)
 endif()
 
+if(MSVC OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+    target_compile_definitions(plutosvg PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()
+
 option(PLUTOSVG_ENABLE_FREETYPE "Enable Freetype integration" OFF)
 if(PLUTOSVG_ENABLE_FREETYPE)
     find_package(Freetype 2.12 REQUIRED)

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,10 @@ if math_dep.found()
     plutosvg_deps += [math_dep]
 endif
 
+if cc.get_id() == 'msvc' or cc.get_id() == 'clang' or cc.get_id() == 'clang-cl'
+    plutovg_c_args += ['-D_CRT_SECURE_NO_WARNINGS']
+endif
+
 freetype_dep = dependency('freetype2',
     required: get_option('freetype'),
     version: '>=2.12',

--- a/source/plutosvg-ft.h
+++ b/source/plutosvg-ft.h
@@ -149,7 +149,7 @@ static FT_Error plutosvg_ft_render(FT_GlyphSlot ft_slot, FT_Pointer* ft_state)
     char buffer[64];
     char* id = NULL;
     if(start_glyph_id < end_glyph_id) {
-        sprintf(buffer, "glyph%u", ft_slot->glyph_index);
+        sprintf_s(buffer, sizeof(buffer), "glyph%u", ft_slot->glyph_index);
         id = buffer;
     }
 
@@ -231,7 +231,7 @@ static FT_Error plutosvg_ft_preset_slot(FT_GlyphSlot ft_slot, FT_Bool ft_cache, 
     char buffer[64];
     char* id = NULL;
     if(start_glyph_id < end_glyph_id) {
-        sprintf(buffer, "glyph%u", ft_slot->glyph_index);
+        sprintf_s(buffer, sizeof(buffer), "glyph%u", ft_slot->glyph_index);
         id = buffer;
     }
 

--- a/source/plutosvg-ft.h
+++ b/source/plutosvg-ft.h
@@ -58,6 +58,11 @@
 #ifndef PLUTOSVG_FT_H
 #define PLUTOSVG_FT_H
 
+#if _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
 #include "plutosvg.h"
 
 #include <stdlib.h>
@@ -288,5 +293,9 @@ static SVG_RendererHooks plutosvg_ft_hooks = {
     (SVG_Lib_Render_Func)plutosvg_ft_render,
     (SVG_Lib_Preset_Slot_Func)plutosvg_ft_preset_slot
 };
+
+#if _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // PLUTOSVG_FT_H

--- a/source/plutosvg-ft.h
+++ b/source/plutosvg-ft.h
@@ -149,7 +149,7 @@ static FT_Error plutosvg_ft_render(FT_GlyphSlot ft_slot, FT_Pointer* ft_state)
     char buffer[64];
     char* id = NULL;
     if(start_glyph_id < end_glyph_id) {
-        sprintf_s(buffer, sizeof(buffer), "glyph%u", ft_slot->glyph_index);
+        sprintf(buffer, "glyph%u", ft_slot->glyph_index);
         id = buffer;
     }
 
@@ -231,7 +231,7 @@ static FT_Error plutosvg_ft_preset_slot(FT_GlyphSlot ft_slot, FT_Bool ft_cache, 
     char buffer[64];
     char* id = NULL;
     if(start_glyph_id < end_glyph_id) {
-        sprintf_s(buffer, sizeof(buffer), "glyph%u", ft_slot->glyph_index);
+        sprintf(buffer, "glyph%u", ft_slot->glyph_index);
         id = buffer;
     }
 


### PR DESCRIPTION
Makes PlutoSVG more secure (theoretically) and silences compiler warnings at high settings.