### PR TITLE
Return NULL from load_image when href is missing

### DIFF
--- a/source/plutosvg.c
+++ b/source/plutosvg.c
@@ -2427,7 +2427,7 @@ static plutovg_surface_t* load_image(const element_t* element)
 {
     const string_t* value = find_attribute(element, ATTR_HREF, false);
     if(value == NULL)
-        return false;
+        return NULL;
     const char* it = value->data;
     const char* end = it + value->length;
     if(!skip_string(&it, end, "data:image/png")


### PR DESCRIPTION
`load_image` is declared `static plutovg_surface_t*`; the missing-href branch returns `false`. Every other return in the function uses `NULL` (lines 2436, 2441). The current code works on every reasonable ABI (`false == 0` converts to a null pointer) but trips `-Wint-conversion` and is gratuitous noise next to the consistent `NULL` returns nearby.